### PR TITLE
docs: add BP300CL / KD723SE / KN550LT (iOS 2.15.0 & Android 2.16.0)

### DIFF
--- a/docs/android/blood_pressure/bp300cl.mdx
+++ b/docs/android/blood_pressure/bp300cl.mdx
@@ -1,0 +1,305 @@
+---
+title: BP300CL
+sidebar_position: 10
+---
+
+The Android SDK supports BP300CL in v2.16.0 and above.
+
+:::info
+1. Scan and connect the BP-300CL blood pressure monitor.
+2. Use `MemoryDataGroupNumberBp300Cv` to read memory for user group 1, user group 2, or all
+   (`GROUP_1` → user id `1`, `GROUP_2` → `2`, `GROUP_ALL` → `254` on the wire).
+:::
+
+## Connection to device
+
+### 1. Listen to device notify
+
+```java
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+
+    @Override
+    public void onScanDevice(String mac, String deviceType, int rssi, Map manufactorData) { }
+
+    @Override
+    public void onDeviceConnectionStateChange(String mac, String deviceType, int status, int errorID, Map manufactorData){ }
+
+    @Override
+    public void onScanError(String reason, long latency) { }
+
+    @Override
+    public void onScanFinish() { }
+
+    @Override
+    public void onDeviceNotify(String mac, String deviceType,
+                                String action, String message) { }
+};
+int callbackId = iHealthDevicesManager.getInstance().registerClientCallback(miHealthDevicesCallback);
+iHealthDevicesManager.getInstance().addCallbackFilterForDeviceType(callbackId, iHealthDevicesManager.TYPE_BP300CL);
+iHealthDevicesManager.getInstance().addCallbackFilterForAddress(callbackId, String... macs);
+```
+
+### 2. Scan for BP-300CL devices
+
+```java
+iHealthDevicesManager.getInstance().startDiscovery(DiscoveryTypeEnum.BP300CL);
+```
+
+### 3. Connect to BP-300CL devices
+
+```java
+iHealthDevicesManager.getInstance().connectDevice("", mac, iHealthDevicesManager.TYPE_BP300CL);
+
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mac);
+```
+
+## API reference
+
+### Get battery
+
+```java
+import com.ihealth.communication.control.Bp300ClControl;
+import com.ihealth.communication.manager.iHealthDevicesManager;
+
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.getBattery();
+```
+
+```java
+// Return value — action: Bp300ClMessageKey.ACTION_BATTERY_CBP
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Bp300ClMessageKey.ACTION_BATTERY_CBP.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int battery = obj.getInt(Bp300CvMessageKey.BATTERY_BP); // 0-100
+                int batteryStatus = obj.getInt(BpProfile.BATTERY_STATUS); // charging status
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get device IDPS
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.getIdps();
+```
+
+```java
+// Return value — action: Bp300ClMessageKey.ACTION_IDPS_BP300CL
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Bp300ClMessageKey.ACTION_IDPS_BP300CL.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                String firmwareVersion = obj.getString(iHealthDevicesIDPS.FIRMWAREVERSION);
+                String hardwareVersion = obj.getString(iHealthDevicesIDPS.HARDWAREVERSION);
+                String protocolString = obj.getString(iHealthDevicesIDPS.PROTOCOLSTRING);
+                String accessoryName = obj.getString(iHealthDevicesIDPS.ACCESSORYNAME);
+                String modelNumber = obj.getString(iHealthDevicesIDPS.MODENUMBER);
+                String manufacturer = obj.getString(iHealthDevicesIDPS.MANUFACTURER);
+                String serialNumber = obj.getString(iHealthDevicesIDPS.SERIALNUMBER);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get function information
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.getFunctionInfo();
+```
+
+```java
+// Return value — action: Bp300ClMessageKey.ACTION_FUNCTION_INFORMATION_BP
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Bp300ClMessageKey.ACTION_FUNCTION_INFORMATION_BP.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                boolean haveOffline = obj.getBoolean(BpProfile.FUNCTION_HAVE_OFFLINE);
+                boolean haveThreeMeasureSetting = obj.getBoolean(Bp300ClMessageKey.HAVE_THREE_MEASURE_SETTING);
+                boolean haveVoice = obj.getBoolean(Bp300ClMessageKey.HAVE_VOICE);
+                boolean haveHRV = obj.getBoolean(Bp300ClMessageKey.HAVE_HRV);
+                int memoryGroup = obj.getInt(BpProfile.MEMORY_GROUP);
+                int maxMemoryCapacity = obj.getInt(BpProfile.MAX_MEMORY_CAPACITY);
+                boolean selfUpdate = obj.getBoolean(BpProfile.FUNCTION_HAVE_SELF_UPDATE);
+                String deviceTime = obj.getString(BpProfile.DEVICE_TIME);
+                String deviceSysTime = obj.getString(BpProfile.DEVICE_SYS_TIME);
+                int currentUser = obj.getInt(BpProfile.CURRENT_USER);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get memory record count
+
+```java
+import com.ihealth.sdk.constants.MemoryDataGroupNumberBp300Cv;
+
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.getMemoryCount(MemoryDataGroupNumberBp300Cv.GROUP_1);
+```
+
+```java
+// Return value — action: Bp300ClMessageKey.ACTION_GET_MEMORY_COUNT
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Bp300ClMessageKey.ACTION_GET_MEMORY_COUNT.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int count = obj.getInt(BpProfile.MEMORY_COUNT);
+                int group = obj.getInt(BpProfile.FUNCTION_MEMORY_GROUP);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get latest memory data
+
+Returns up to two most-recent records keyed by `Bp300ClMessageKey.LATEST_MEMORY_DATA1` /
+`LATEST_MEMORY_DATA2`. Each record shares the fields of a memory record (see below).
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.getLatestMemoryData();
+```
+
+```java
+// Return value — action: Bp300ClMessageKey.ACTION_GET_LATEST_MEMORY_DATA
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Bp300ClMessageKey.ACTION_GET_LATEST_MEMORY_DATA.equals(action)) {
+            try {
+                JSONObject root = new JSONObject(message);
+                JSONObject data1 = root.optJSONObject(Bp300ClMessageKey.LATEST_MEMORY_DATA1);
+                JSONObject data2 = root.optJSONObject(Bp300ClMessageKey.LATEST_MEMORY_DATA2);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get memory (history) data
+
+Data arrive in one or more BLE packets; the SDK assembles them and delivers a single notify
+when the transfer is complete.
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.getMemoryData(MemoryDataGroupNumberBp300Cv.GROUP_1);
+```
+
+```java
+// Return value — action: BpProfile.ACTION_GET_MEMORY_DATA
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_GET_MEMORY_DATA.equals(action)) {
+            try {
+                JSONObject root = new JSONObject(message);
+                JSONArray historyArr = root.getJSONArray(BpProfile.MEMORY_DATA);
+                for (int i = 0; i < historyArr.length(); i++) {
+                    JSONObject obj = historyArr.getJSONObject(i);
+                    String time = obj.getString(BpProfile.MEASUREMENT_DATE_BP);
+                    int sys = obj.getInt(BpProfile.HIGH_BLOOD_PRESSURE_BP);
+                    int dia = obj.getInt(BpProfile.LOW_BLOOD_PRESSURE_BP);
+                    int heartRate = obj.getInt(BpProfile.PULSE_BP);
+                    boolean irregular = obj.getBoolean(BpProfile.IRREGULAR);
+                    boolean bodyMovement = obj.getBoolean(BpProfile.BODY_MOVEMENT);
+                    boolean cuffLoose = obj.getBoolean(BpProfile.CUF_LOOSE);
+                    int timeFlag = obj.getInt(Bp300ClMessageKey.TIME_FLAG);
+                    int measureFlag = obj.getInt(Bp300ClMessageKey.MEASURE_FLAG);
+                    String dataID = obj.getString(BpProfile.DATAID);
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Finish reading memory data
+
+After reading the history you can acknowledge/finalize the transfer for the given user group.
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.finishGetMemoryData(MemoryDataGroupNumberBp300Cv.GROUP_1);
+```
+
+```java
+// Return value — action: BpProfile.ACTION_DELETE_MEMORY_DATA (message is often empty)
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_DELETE_MEMORY_DATA.equals(action)) {
+            // Finish completed
+        }
+    }
+};
+```
+
+### Disconnect BP-300CL device
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+control.disconnect();
+```
+
+```java
+// Return value
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+     @Override
+    public void onDeviceConnectionStateChange(String mac, String deviceType, int status, int errorID, Map manufactorData) {
+        if (iHealthDevicesManager.DEVICE_STATE_DISCONNECTED == status) {
+            // Disconnected
+        }
+    }
+};
+```
+
+### Release control (optional)
+
+```java
+Bp300ClControl control = iHealthDevicesManager.getInstance().getBp300ClControl(mDeviceMac);
+if (control != null) {
+    control.destroy();
+}
+```
+
+### Errors and command timeout
+
+`Bp300ClControl` treats `Bp300ClMessageKey.ACTION_ERROR_BP` (`error_bp`), communication timeout
+(`action_communication_timeout`), and the actions listed above as completion paths. Compare
+`action` with `iHealthDevicesManager.IHEALTH_COMM_TIMEOUT` where you handle timeouts globally.
+
+```java
+if (Bp300ClMessageKey.ACTION_ERROR_BP.equals(action)) {
+    JSONObject obj = new JSONObject(message);
+    int errorId = obj.getInt(BpProfile.ERROR_NUM_BP);
+    String errorMessage = obj.getString(BpProfile.ERROR_DESCRIPTION_BP);
+}
+```

--- a/docs/android/blood_pressure/kd723se.mdx
+++ b/docs/android/blood_pressure/kd723se.mdx
@@ -1,0 +1,284 @@
+---
+title: KD723SE
+sidebar_position: 9
+---
+
+The Android SDK supports KD723SE in v2.16.0 and above.
+
+:::info
+1. Scan and connect the KD-723SE blood pressure monitor (encrypted "new protocol" device).
+2. Use `MemoryDataGroupNumberKd723se` to read/delete memory for user group 1 or group 2
+   (`GROUP_1` → user id `0`, `GROUP_2` → `1` on the wire). `GROUP_ALL` is **not** supported by
+   memory count / memory data on this device.
+:::
+
+## Connection to device
+
+### 1. Listen to device notify
+
+```java
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+
+    @Override
+    public void onScanDevice(String mac, String deviceType, int rssi, Map manufactorData) { }
+
+    @Override
+    public void onDeviceConnectionStateChange(String mac, String deviceType, int status, int errorID, Map manufactorData){ }
+
+    @Override
+    public void onScanError(String reason, long latency) { }
+
+    @Override
+    public void onScanFinish() { }
+
+    @Override
+    public void onDeviceNotify(String mac, String deviceType,
+                                String action, String message) { }
+};
+int callbackId = iHealthDevicesManager.getInstance().registerClientCallback(miHealthDevicesCallback);
+iHealthDevicesManager.getInstance().addCallbackFilterForDeviceType(callbackId, iHealthDevicesManager.TYPE_KD723SE);
+iHealthDevicesManager.getInstance().addCallbackFilterForAddress(callbackId, String... macs);
+```
+
+### 2. Scan for KD-723SE devices
+
+```java
+iHealthDevicesManager.getInstance().startDiscovery(DiscoveryTypeEnum.KD723SE);
+```
+
+### 3. Connect to KD-723SE devices
+
+```java
+iHealthDevicesManager.getInstance().connectDevice("", mac, iHealthDevicesManager.TYPE_KD723SE);
+
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mac);
+```
+
+## API reference
+
+### Set device time
+
+Sends the phone’s current date and time (default time zone) to the device. The boolean argument is **24-hour clock on the device** (`true` = 24-hour mode).
+
+```java
+import com.ihealth.communication.control.Kd723seControl;
+import com.ihealth.communication.manager.iHealthDevicesManager;
+
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.setTime(true);
+```
+
+```java
+// Return value — success (message is often empty)
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_SET_TIME.equals(action)) {
+            // Time set completed
+        } else if (BpProfile.ACTION_ERROR_BP.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int errorId = obj.getInt(BpProfile.ERROR_NUM_BP);
+                String errorMessage = obj.getString(BpProfile.ERROR_DESCRIPTION_BP);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get function information
+
+Returns capability flags, firmware/hardware version strings, the device time string, the
+clock mode and IDPS fields. The JSON uses `BpProfile` key names.
+
+```java
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.getFunctionInfo();
+```
+
+```java
+// Return value — action: BpProfile.ACTION_FUNCTION_INFORMATION_BP
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_FUNCTION_INFORMATION_BP.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int lastOperatingState = obj.getInt(BpProfile.LAST_OPERATING_STATE);
+                boolean haveOffline = obj.getBoolean(BpProfile.FUNCTION_HAVE_OFFLINE);
+                int memoryGroup = obj.getInt(BpProfile.MEMORY_GROUP);
+                int maxMemoryCapacity = obj.getInt(BpProfile.MAX_MEMORY_CAPACITY);
+                boolean selfUpdate = obj.getBoolean(BpProfile.FUNCTION_HAVE_SELF_UPDATE);
+                String deviceTime = obj.getString(BpProfile.DEVICE_TIME);
+                boolean is24Hour = obj.getBoolean(BpProfile.IS_24_HOUR);
+                String protocol = obj.getString(BpProfile.PROTOCOL);
+                String accessoryName = obj.getString(BpProfile.ACCESSORY_NAME);
+                String firmwareVersion = obj.getString(BpProfile.FIRMWARE_VERSION);
+                String hardwareVersion = obj.getString(BpProfile.HARDWARE_VERSION);
+                String manufacturer = obj.getString(BpProfile.MANUFACTURER);
+                String modelNumber = obj.getString(BpProfile.MODEL_NUMBER);
+                String serialNumber = obj.getString(BpProfile.SERIAL_NUMBER);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get memory record count
+
+```java
+import com.ihealth.sdk.constants.MemoryDataGroupNumberKd723se;
+
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.getMemoryCount(MemoryDataGroupNumberKd723se.GROUP_1);
+```
+
+```java
+// Return value — action: BpProfile.ACTION_GET_MEMORY_COUNT
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_GET_MEMORY_COUNT.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int count = obj.getInt(BpProfile.MEMORY_COUNT);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get latest memory data
+
+Returns up to two most-recent records (one per user group), keyed by
+`Kd723SEMessageKey.LATEST_MEMORY_DATA1` / `LATEST_MEMORY_DATA2`. Each record shares the
+fields of a memory record (see below).
+
+```java
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.getLatestMemoryData();
+```
+
+```java
+// Return value — action: Kd723SEMessageKey.ACTION_GET_LATEST_MEMORY_DATA
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kd723SEMessageKey.ACTION_GET_LATEST_MEMORY_DATA.equals(action)) {
+            try {
+                JSONObject root = new JSONObject(message);
+                JSONObject data1 = root.optJSONObject(Kd723SEMessageKey.LATEST_MEMORY_DATA1);
+                JSONObject data2 = root.optJSONObject(Kd723SEMessageKey.LATEST_MEMORY_DATA2);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get memory (history) data
+
+Data arrive in one or more BLE packets; the SDK assembles them and delivers a single notify
+when the transfer is complete.
+
+```java
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.getMemoryData(MemoryDataGroupNumberKd723se.GROUP_1);
+```
+
+```java
+// Return value — action: BpProfile.ACTION_GET_MEMORY_DATA
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_GET_MEMORY_DATA.equals(action)) {
+            try {
+                JSONObject root = new JSONObject(message);
+                JSONArray historyArr = root.getJSONArray(BpProfile.MEMORY_DATA);
+                for (int i = 0; i < historyArr.length(); i++) {
+                    JSONObject obj = historyArr.getJSONObject(i);
+                    String time = obj.getString(BpProfile.MEASUREMENT_DATE_BP);
+                    int sys = obj.getInt(BpProfile.HIGH_BLOOD_PRESSURE_BP);
+                    int dia = obj.getInt(BpProfile.LOW_BLOOD_PRESSURE_BP);
+                    int heartRate = obj.getInt(BpProfile.PULSE_BP);
+                    int schemeId = obj.getInt(BpProfile.SCHEME_ID);
+                    boolean irregular = obj.getBoolean(BpProfile.IRREGULAR);
+                    boolean bodyMovement = obj.getBoolean(BpProfile.BODY_MOVEMENT);
+                    boolean isRightTime = obj.getBoolean(BpProfile.IS_RIGHT_TIME);
+                    String dataID = obj.getString(BpProfile.DATAID);
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Delete memory data
+
+```java
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.deleteMemoryData(MemoryDataGroupNumberKd723se.GROUP_1);
+```
+
+```java
+// Return value — action: BpProfile.ACTION_DELETE_MEMORY_DATA (message is often empty)
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_DELETE_MEMORY_DATA.equals(action)) {
+            // Delete completed
+        }
+    }
+};
+```
+
+### Disconnect KD-723SE device
+
+```java
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+control.disconnect();
+```
+
+```java
+// Return value
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+     @Override
+    public void onDeviceConnectionStateChange(String mac, String deviceType, int status, int errorID, Map manufactorData) {
+        if (iHealthDevicesManager.DEVICE_STATE_DISCONNECTED == status) {
+            // Disconnected
+        }
+    }
+};
+```
+
+### Release control (optional)
+
+```java
+Kd723seControl control = iHealthDevicesManager.getInstance().getKd723seControl(mDeviceMac);
+if (control != null) {
+    control.destroy();
+}
+```
+
+### Errors and command timeout
+
+`Kd723seControl` treats `BpProfile.ACTION_ERROR_BP` (`error_bp`), communication timeout
+(`action_communication_timeout`), and the actions listed above as completion paths. Compare
+`action` with `iHealthDevicesManager.IHEALTH_COMM_TIMEOUT` where you handle timeouts globally.
+
+```java
+if (BpProfile.ACTION_ERROR_BP.equals(action)) {
+    JSONObject obj = new JSONObject(message);
+    int errorId = obj.getInt(BpProfile.ERROR_NUM_BP);
+    String errorMessage = obj.getString(BpProfile.ERROR_DESCRIPTION_BP);
+}
+```

--- a/docs/android/blood_pressure/kn550lt.mdx
+++ b/docs/android/blood_pressure/kn550lt.mdx
@@ -1,0 +1,291 @@
+---
+title: KN550LT
+sidebar_position: 11
+---
+
+The Android SDK supports KN550LT in v2.16.0 and above.
+
+:::info
+1. Scan and connect the KN-550LT blood pressure monitor.
+2. KN-550LT keeps a single memory bank — `getMemoryCount` / `getMemoryData` / `deleteMemoryData`
+   take no user-group argument.
+:::
+
+## Connection to device
+
+### 1. Listen to device notify
+
+```java
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+
+    @Override
+    public void onScanDevice(String mac, String deviceType, int rssi, Map manufactorData) { }
+
+    @Override
+    public void onDeviceConnectionStateChange(String mac, String deviceType, int status, int errorID, Map manufactorData){ }
+
+    @Override
+    public void onScanError(String reason, long latency) { }
+
+    @Override
+    public void onScanFinish() { }
+
+    @Override
+    public void onDeviceNotify(String mac, String deviceType,
+                                String action, String message) { }
+};
+int callbackId = iHealthDevicesManager.getInstance().registerClientCallback(miHealthDevicesCallback);
+iHealthDevicesManager.getInstance().addCallbackFilterForDeviceType(callbackId, iHealthDevicesManager.TYPE_KN550LT);
+iHealthDevicesManager.getInstance().addCallbackFilterForAddress(callbackId, String... macs);
+```
+
+### 2. Scan for KN-550LT devices
+
+```java
+iHealthDevicesManager.getInstance().startDiscovery(DiscoveryTypeEnum.KN550LT);
+```
+
+### 3. Connect to KN-550LT devices
+
+```java
+iHealthDevicesManager.getInstance().connectDevice("", mac, iHealthDevicesManager.TYPE_KN550LT);
+
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mac);
+```
+
+## API reference
+
+### Get device IDPS
+
+```java
+import com.ihealth.communication.control.Kn550LtControl;
+import com.ihealth.communication.manager.iHealthDevicesManager;
+
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.getIdps();
+```
+
+```java
+// Return value — action: Kn550LtMessageKey.ACTION_IDPS_KN550
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kn550LtMessageKey.ACTION_IDPS_KN550.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                String firmwareVersion = obj.getString(iHealthDevicesIDPS.FIRMWAREVERSION);
+                String hardwareVersion = obj.getString(iHealthDevicesIDPS.HARDWAREVERSION);
+                String protocolString = obj.getString(iHealthDevicesIDPS.PROTOCOLSTRING);
+                String accessoryName = obj.getString(iHealthDevicesIDPS.ACCESSORYNAME);
+                String modelNumber = obj.getString(iHealthDevicesIDPS.MODENUMBER);
+                String manufacturer = obj.getString(iHealthDevicesIDPS.MANUFACTURER);
+                String serialNumber = obj.getString(iHealthDevicesIDPS.SERIALNUMBER);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get battery
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.getBattery();
+```
+
+```java
+// Return value — action: Kn550LtMessageKey.ACTION_BATTERY_BP
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kn550LtMessageKey.ACTION_BATTERY_BP.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int battery = obj.getInt(Kn550LtMessageKey.BATTERY_BP); // 0-100
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get device time
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.getTime();
+```
+
+```java
+// Return value — action: BpProfile.ACTION_GET_TIME
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (BpProfile.ACTION_GET_TIME.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                String deviceTime = obj.getString(BpProfile.DEVICE_TIME);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get function information
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.getFunctionInfo();
+```
+
+```java
+// Return value — action: Kn550LtMessageKey.ACTION_FUNCTION_INFORMATION_BP
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kn550LtMessageKey.ACTION_FUNCTION_INFORMATION_BP.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int status = obj.getInt(Kn550LtMessageKey.STATUS);
+                boolean haveOffline = obj.getBoolean(Kn550LtMessageKey.FUNCTION_HAVE_OFFLINE);
+                boolean armMeasure = obj.getBoolean(Kn550LtMessageKey.FUNCTION_IS_ARM_MEASURE);
+                int memoryGroup = obj.getInt(Kn550LtMessageKey.MEMORY_GROUP);
+                int maxMemoryCapacity = obj.getInt(Kn550LtMessageKey.MAX_MEMORY_CAPACITY);
+                boolean selfUpdate = obj.getBoolean(Kn550LtMessageKey.FUNCTION_HAVE_SELF_UPDATE);
+                int showUnit = obj.getInt(Kn550LtMessageKey.SHOW_UNIT);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get memory record count
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.getMemoryCount();
+```
+
+```java
+// Return value — action: Kn550LtMessageKey.ACTION_GET_MEMORY_COUNT
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kn550LtMessageKey.ACTION_GET_MEMORY_COUNT.equals(action)) {
+            try {
+                JSONObject obj = new JSONObject(message);
+                int count = obj.getInt(Kn550LtMessageKey.MEMORY_COUNT);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Get memory (history) data
+
+Data arrive in one or more BLE packets; the SDK assembles them and delivers a single notify
+when the transfer is complete.
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.getMemoryData();
+```
+
+```java
+// Return value — action: Kn550LtMessageKey.ACTION_GET_MEMORY_DATA
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kn550LtMessageKey.ACTION_GET_MEMORY_DATA.equals(action)) {
+            try {
+                JSONObject root = new JSONObject(message);
+                JSONArray historyArr = root.getJSONArray(Kn550LtMessageKey.MEMORY_DATA);
+                for (int i = 0; i < historyArr.length(); i++) {
+                    JSONObject obj = historyArr.getJSONObject(i);
+                    String time = obj.getString(Kn550LtMessageKey.MEASUREMENT_DATE_BP);
+                    int sys = obj.getInt(Kn550LtMessageKey.HIGH_BLOOD_PRESSURE_BP);
+                    int dia = obj.getInt(Kn550LtMessageKey.LOW_BLOOD_PRESSURE_BP);
+                    int heartRate = obj.getInt(Kn550LtMessageKey.PULSE_BP);
+                    boolean bodyMovement = obj.getBoolean(Kn550LtMessageKey.BODY_MOVEMENT);
+                    boolean cuffLoose = obj.getBoolean(Kn550LtMessageKey.CUF_LOOSE);
+                    boolean haveIHB = obj.getBoolean(Kn550LtMessageKey.HAVE_IHB);
+                    int timeFlag = obj.getInt(Kn550LtMessageKey.TIME_FLAG);
+                    String dataID = obj.getString(Kn550LtMessageKey.DATAID);
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+};
+```
+
+### Delete memory data
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.deleteMemoryData();
+```
+
+```java
+// Return value — action: Kn550LtMessageKey.ACTION_DELETE_MEMORY_DATA (message is often empty)
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+    @Override
+    public void onDeviceNotify(String mac, String deviceType, String action, String message) {
+        if (Kn550LtMessageKey.ACTION_DELETE_MEMORY_DATA.equals(action)) {
+            // Delete completed
+        }
+    }
+};
+```
+
+### Disconnect KN-550LT device
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+control.disconnect();
+```
+
+```java
+// Return value
+private iHealthDevicesCallback miHealthDevicesCallback = new iHealthDevicesCallback() {
+     @Override
+    public void onDeviceConnectionStateChange(String mac, String deviceType, int status, int errorID, Map manufactorData) {
+        if (iHealthDevicesManager.DEVICE_STATE_DISCONNECTED == status) {
+            // Disconnected
+        }
+    }
+};
+```
+
+### Release control (optional)
+
+```java
+Kn550LtControl control = iHealthDevicesManager.getInstance().getKn550LtControl(mDeviceMac);
+if (control != null) {
+    control.destroy();
+}
+```
+
+### Errors and command timeout
+
+`Kn550LtControl` treats `Kn550LtMessageKey.ACTION_ERROR_BP` (`error_bp`), communication timeout
+(`action_communication_timeout`), and the actions listed above as completion paths. Compare
+`action` with `iHealthDevicesManager.IHEALTH_COMM_TIMEOUT` where you handle timeouts globally.
+
+```java
+if (Kn550LtMessageKey.ACTION_ERROR_BP.equals(action)) {
+    JSONObject obj = new JSONObject(message);
+    int errorId = obj.getInt(BpProfile.ERROR_NUM_BP);
+    String errorMessage = obj.getString(BpProfile.ERROR_DESCRIPTION_BP);
+}
+```

--- a/docs/ios/blood_pressure/bp300cl.md
+++ b/docs/ios/blood_pressure/bp300cl.md
@@ -1,0 +1,164 @@
+---
+title: BP300CL
+sidebar_position: 12
+---
+
+The iOS SDK supports BP300CL in versions 2.15.0 and above.
+
+## WorkFlow
+
+1. Scan and connect BP300CL blood pressure monitor.
+
+2. BP300CL supports online and offline measurement.
+
+In the iOS SDK, use `HealthDeviceType_BP300CL` to scan for this device. Offline memory is organized by user group: use `BP300CLMemoryDataGroupNumber_Group1`, `BP300CLMemoryDataGroupNumber_Group2`, or `BP300CLMemoryDataGroupNumber_All` when reading or deleting history.
+
+## Connection to device
+
+### 1.Listen to device notify
+
+```java
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(deviceDiscovered:) name:BP300CLDiscover object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(deviceConnectFailed:) name:BP300CLConnectFailed object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(DeviceConnected:) name:BP300CLConnectNoti object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(DeviceDisconnected:) name:BP300CLDisConnectNoti object:nil];
+
+[BP300CLController shareIHBP300CLController];
+```
+
+### 2.Scan for devices
+
+```java
+[[ScanDeviceController commandGetInstance] commandScanDeviceType:HealthDeviceType_BP300CL];
+```
+
+### 3.Connect to devices
+
+```java
+[[ConnectDeviceController commandGetInstance] commandContectDeviceWithDeviceType:HealthDeviceType_BP300CL andSerialNub:deviceMac];
+```
+
+### 4.Get the device instance
+
+```java
+BP300CL *device = [[BP300CLController shareIHBP300CLController] getInstanceWithMac:deviceMac];
+```
+
+## API reference
+
+### Get IDPS info
+
+```java
+/**
+ * Get IDPS info
+ * @param idpsInfo  A block to refer ‘idpsInfo’.
+ * @param error   A block to return the error.
+ */
+-(void)commandGetIDPSInfo:(BlockDeviceIDPS)idpsInfo errorBlock:(BlockError)error;
+```
+
+### Get battery energy
+
+```java
+/**
+ * Query battery remaining energy.
+ * @param energyValue  A block to return the device battery remaining energy percentage, ‘80’ stands for 80%.
+ * @param energyState 0:Not charging 1:charging
+ * @param error  A block to return the error.
+ */
+-(void)commandEnergy:(BlockEnergyValue)energyValue energyState:(BlockEnergyState)energyState errorBlock:(BlockError)error;
+```
+
+### Get Function
+
+```java
+/**
+ *
+ * What the function returns:
+
+ voiceSetting = 0;
+ currentUser = 2;
+ upAirMeasureFlg = 0;
+ deviceSysTime = 2025-06-27 06:18:04 +0000;
+ haveOffline = 1;
+ deviceTime = 2025-01-01 07:46:21 +0000;
+ haveCuffLooseFlg = 0;
+ haveBodyMovementFlg = 0;
+ showUnit = 0;
+ selfUpdate = 0;
+ haveMarking = 1;
+ haveAngleSet = 0;
+ armMeasureFlg = 1;
+ haveShowUnitSetting = 0;
+ mutableUpload = 0;
+ haveBackLightSetting = 0;
+ haveClockShowSetting = 0;
+ haveAngleSensor = 0;
+ memoryGroup = 2;
+ haveRepeatedlyMeasure = 0;
+ haveHSD = 0;
+ * @param function  A block to return the function and states that the device supports.
+ * @param error   A block to return the error.
+ */
+-(void)commandFunction:(BlockDeviceFunction)function errorBlock:(BlockError)error;
+```
+
+### Get latest data
+
+```java
+/**
+ * Get the latest memory data of User 1 and User 2.
+ * @param result1Dic  Latest data of User 1.
+ * @param result2Dic  Latest data of User 2.
+ * @param error  A block to return the error.
+ */
+-(void)commandGetLatestMemoryDataGroup1:(BlockMeasureResult)result1Dic group2:(BlockMeasureResult)result2Dic errorBlock:(BlockError)error;
+```
+
+### Get history data count
+
+```java
+/**
+ * Upload offline data total Count.
+ * @param groupID    Memory group: BP300CLMemoryDataGroupNumber_Group1, _Group2, or _All.
+ * @param  totalCount item quantity of total data count
+ * @param error  A block to return the error.
+ */
+-(void)commandGetMemoryCountWithGroupID:(BP300CLMemoryDataGroupNumber)groupID count:(BlockBachCount)totalCount errorBlock:(BlockError)error;
+```
+
+### Get history data
+
+```java
+/**
+ * Upload offline data（Please call the API for obtaining the number of historical data before calling this API, otherwise the data cannot be obtained.）
+ * @param groupID   Memory group: BP300CLMemoryDataGroupNumber_Group1, _Group2, or _All.
+ * @param uploadDataArray item quantity of total data.
+ * @param error  A block to return the error.
+ */
+-(void)commandTransferMemoryDataWithGroupID:(BP300CLMemoryDataGroupNumber)groupID data:(BlockBachArray)uploadDataArray errorBlock:(BlockError)error;
+```
+
+### Delete history data
+
+```java
+/**
+ * Delete offline data.
+ * @param groupID  Memory group: BP300CLMemoryDataGroupNumber_Group1, _Group2, or _All.
+ * @param success   A block to refer ‘set success’.
+ * @param error    A block to return the error.
+ */
+-(void)commandDeleteMemoryDataWithGroupID:(BP300CLMemoryDataGroupNumber)groupID success:(BlockSuccess)success errorBlock:(BlockError)error;
+```
+
+### Disconnect device
+
+```java
+/**
+ * Disconnect current device
+ */
+-(void)commandDisconnectDevice;
+```

--- a/docs/ios/blood_pressure/kd723se.md
+++ b/docs/ios/blood_pressure/kd723se.md
@@ -1,0 +1,154 @@
+---
+title: KD723SE
+sidebar_position: 13
+---
+
+The iOS SDK supports KD723SE in versions 2.15.0 and above.
+
+## WorkFlow
+
+1. Scan and connect KD723SE blood pressure monitor.
+
+2. KD723SE supports online and offline measurement.
+
+In the iOS SDK, use `HealthDeviceType_KD723SE` to scan for this device. Offline memory is organized by user group: use `KD723SEMemoryDataGroupNumber_Group1`, `KD723SEMemoryDataGroupNumber_Group2`, or `KD723SEMemoryDataGroupNumber_All` when reading or deleting history.
+
+## Connection to device
+
+### 1.Listen to device notify
+
+```java
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(deviceDiscovered:) name:KD723SEDiscover object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(deviceConnectFailed:) name:KD723SEConnectFailed object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(DeviceConnected:) name:KD723SEConnectNoti object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(DeviceDisconnected:) name:KD723SEDisConnectNoti object:nil];
+
+[KD723SEController shareIHKD723SEController];
+```
+
+### 2.Scan for devices
+
+```java
+[[ScanDeviceController commandGetInstance] commandScanDeviceType:HealthDeviceType_KD723SE];
+```
+
+### 3.Connect to devices
+
+```java
+[[ConnectDeviceController commandGetInstance] commandContectDeviceWithDeviceType:HealthDeviceType_KD723SE andSerialNub:deviceMac];
+```
+
+### 4.Get the device instance
+
+```java
+KD723SE *device = [[KD723SEController shareIHKD723SEController] getInstanceWithMac:deviceMac];
+```
+
+## API reference
+
+### Set local time to device
+
+```java
+/**
+ * synchronize time
+ * @param success  A block to refer ‘set success’.
+ * @param error   A block to return the error.
+ */
+-(void)commandSynchronizeTime:(BlockSuccess)success errorBlock:(BlockError)error;
+```
+
+### Get Function
+
+```java
+/**
+ *
+ * What the function returns:
+
+ upAirMeasureFlg = 1;
+ haveOffline = 1;
+ deviceTime = "2026-2-9 22:12:38";
+ showUnit = 0;
+ is24Hour = 1;
+ selfUpdate = 0;
+ firmwareVersion = "1.0.0";
+ haveAngleSet = 0;
+ modelNumber = "KD-723SE 11070";
+ armMeasureFlg = 0;
+ haveShowUnitSetting = 0;
+ protocol = "com.jiuan.BPV31";
+ mutableUpload = 1;
+ manufacture = "iHealth";
+ haveBackLightSetting = 0;
+ haveClockShowSetting = 0;
+ hardwareVersion = "1.0.0";
+ haveAngleSensor = 0;
+ memoryGroup = 2;
+ maxMemoryCapacity = 199;
+ accessoryName = "KD723SE";
+ haveRepeatedlyMeasure = 0;
+ haveHSD = 1;
+ * @param function  A block to return the function and states that the device supports.
+ * @param error   A block to return the error.
+ */
+-(void)commandFunction:(BlockDeviceFunction)function errorBlock:(BlockError)error;
+```
+
+### Get latest data
+
+```java
+/**
+ * Get the latest memory data of User 1 and User 2.
+ * @param result1Dic  Latest data of User 1.
+ * @param result2Dic  Latest data of User 2.
+ * @param error  A block to return the error.
+ */
+-(void)commandGetLatestMemoryDataGroup1:(BlockMeasureResult)result1Dic group2:(BlockMeasureResult)result2Dic errorBlock:(BlockError)error;
+```
+
+### Get history data count
+
+```java
+/**
+ * Upload offline data total Count.
+ * @param groupID    User 1 or User 2 only (do not pass KD723SEMemoryDataGroupNumber_All).
+ * @param  totalCount item quantity of total data count
+ * @param error  A block to return the error.
+ */
+-(void)commandGetMemoryCountWithGroupID:(KD723SEMemoryDataGroupNumber)groupID count:(BlockBachCount)totalCount errorBlock:(BlockError)error;
+```
+
+### Get history data
+
+```java
+/**
+ * Upload offline data（Please call the API for obtaining the number of historical data before calling this API, otherwise the data cannot be obtained.）
+ * @param groupID   User 1 or User 2 only (do not pass KD723SEMemoryDataGroupNumber_All).
+ * @param uploadDataArray item quantity of total data.
+ * @param error  A block to return the error.
+ */
+-(void)commandTransferMemoryDataWithGroupID:(KD723SEMemoryDataGroupNumber)groupID data:(BlockBachArray)uploadDataArray errorBlock:(BlockError)error;
+```
+
+### Delete history data
+
+```java
+/**
+ * Delete offline data.
+ * @param groupID  User 1, User 2, or KD723SEMemoryDataGroupNumber_All to delete all offline data.
+ * @param success   A block to refer ‘set success’.
+ * @param error    A block to return the error.
+ */
+-(void)commandDeleteMemoryDataWithGroupID:(KD723SEMemoryDataGroupNumber)groupID success:(BlockSuccess)success errorBlock:(BlockError)error;
+```
+
+### Disconnect device
+
+```java
+/**
+ * Disconnect current device
+ */
+-(void)commandDisconnectDevice;
+```

--- a/docs/ios/blood_pressure/kn550lt.md
+++ b/docs/ios/blood_pressure/kn550lt.md
@@ -1,0 +1,161 @@
+---
+title: KN550LT
+sidebar_position: 11
+---
+
+The iOS SDK supports KN550LT in versions 2.14.0 and above.
+
+## WorkFlow
+
+1. Scan and connect KN550LT blood pressure monitor.
+
+2. KN550LT supports online and offline measurement.
+
+In the iOS SDK, use `HealthDeviceType_KN550LT` to scan for this device.
+
+## Connection to device
+
+### 1.Listen to device notify
+
+```java
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(deviceDiscovered:) name:KN550LTDiscover object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(deviceConnectFailed:) name:KN550LTConnectFailed object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(DeviceConnected:) name:KN550LTConnectNoti object:nil];
+
+[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(DeviceDisconnected:) name:KN550LTDisConnectNoti object:nil];
+
+[KN550LTController shareIHKN550LTController];
+```
+
+### 2.Scan for devices
+
+```java
+[[ScanDeviceController commandGetInstance] commandScanDeviceType:HealthDeviceType_KN550LT];
+```
+
+### 3.Connect to devices
+
+```java
+[[ConnectDeviceController commandGetInstance] commandContectDeviceWithDeviceType:HealthDeviceType_KN550LT andSerialNub:deviceMac];
+```
+
+### 4.Get the device instance
+
+```java
+KN550LT *device = [[KN550LTController shareIHKN550LTController] getInstanceWithMac:deviceMac];
+```
+
+## API reference
+
+### Get IDPS info
+
+```java
+/**
+ * Get IDPS info
+ * @param idpsInfo  A block to refer ‘idpsInfo’.
+ * @param error   A block to return the error.
+ */
+-(void)commandGetIDPSInfo:(BlockDeviceIDPS)idpsInfo errorBlock:(BlockError)error;
+```
+
+### Get battery energy
+
+```java
+/**
+ * Query battery remaining energy.
+ * @param energyValue  A block to return the device battery remaining energy percentage, ‘80’ stands for 80%.
+ * @param error  A block to return the error.
+ */
+-(void)commandEnergy:(BlockEnergyValue)energyValue errorBlock:(BlockError)error;
+```
+
+### Get Function
+
+```java
+/**
+ *
+ * What the function returns:
+
+ currentUser = 1;
+ upAirMeasureFlg = 0;
+ deviceSysTime = 2024-08-19 08:10:58 +0000;
+ haveOffline = 1;
+ deviceTime = 2024-06-30 16:59:13 +0000;
+ haveCuffLooseFlg = 1;
+ haveBodyMovementFlg = 1;
+ showUnit = 0;
+ is24Hour = 1;
+ selfUpdate = 0;
+ firmwareVersion = "1.0.4";
+ haveAngleSet = 0;
+ armMeasureFlg = 1;
+ haveShowUnitSetting = 0;
+ mutableUpload = 0;
+ haveBackLightSetting = 0;
+ haveClockShowSetting = 0;
+ hardwareVersion = "1.0.0";
+ haveAngleSensor = 0;
+ memoryGroup = 2;
+ maxMemoryCapacity = 120;
+ haveRepeatedlyMeasure = 0;
+ haveHSD = 0;
+ * @param function  A block to return the function and states that the device supports.
+ * @param error   A block to return the error.
+ */
+-(void)commandFunction:(BlockDeviceFunction)function errorBlock:(BlockError)error;
+```
+
+### Get device date
+
+```java
+/**
+ * Get Device Date.
+ * @param  date The block return Date, e.g. "2020-01-01 08:56:38"
+ * @param error   error codes.
+ */
+-(void)commandGetDeviceDate:(BlockDeviceDate)date errorBlock:(BlockError)error;
+```
+
+### Get history data count
+
+```java
+/**
+ * Upload offline data total Count.
+ * @param  totalCount item quantity of total data count
+ * @param error  A block to return the error.
+ */
+-(void)commandTransferMemoryCount:(BlockBachCount)totalCount errorBlock:(BlockError)error;
+```
+
+### Get history data
+
+```java
+/**
+ * Upload offline data（Please call the API for obtaining the number of historical data before calling this API, otherwise the data cannot be obtained.）
+ * @param uploadDataArray item quantity of total data.
+ * @param error  A block to return the error.
+ */
+-(void)commandTransferMemoryData:(BlockBachArray)uploadDataArray errorBlock:(BlockError)error;
+```
+
+### Delete history data
+
+```java
+/**
+ * Delete offline data.
+ * @param success   A block to refer ‘set success’.
+ * @param error    A block to return the error.
+ */
+-(void)commandDeleteMemoryDataResult:(BlockSuccess)success errorBlock:(BlockError)error;
+```
+
+### Disconnect device
+
+```java
+/**
+ * Disconnect current device
+ */
+-(void)commandDisconnectDevice;
+```

--- a/docs/ios/quickstart.mdx
+++ b/docs/ios/quickstart.mdx
@@ -168,7 +168,7 @@ When the device is scanned, you can call the connection method to connect the de
 
 ### BP: 
 
-iHealth BP3 、iHealth BP3L、 iHealth BP5 、iHealth BP7 、 iHealth BP7S、 iHealth Continua BP、 iHealth KN550BT、 iHealth ABI 、iHealth ABP100、 iHealth BPM1、 iHealth BP5S、 iHealth KD-5811BT (iOS SDK 2.14.0 and above)
+iHealth BP3 、iHealth BP3L、 iHealth BP5 、iHealth BP7 、 iHealth BP7S、 iHealth Continua BP、 iHealth KN550BT、 iHealth ABI 、iHealth ABP100、 iHealth BPM1、 iHealth BP5S、 iHealth KD-5811BT (iOS SDK 2.14.0 and above)、 iHealth KN550LT (iOS SDK 2.14.0 and above)、 iHealth BP300CL (iOS SDK 2.15.0 and above)、 iHealth KD723SE (iOS SDK 2.15.0 and above)
 
 ### HS: 
 


### PR DESCRIPTION
## Summary
Add documentation for three new blood-pressure devices on both platforms.

### iOS (SDK 2.15.0; KN550LT since 2.14.0)
- New `docs/ios/blood_pressure/` pages: **kn550lt**, **bp300cl**, **kd723se**
- Update `quickstart.mdx` supported-devices list

### Android (SDK 2.16.0)
- New `docs/android/blood_pressure/` pages: **kn550lt**, **bp300cl**, **kd723se**
- KD723SE page does not include OTA (kept consistent with iOS)

Verified locally with the Docusaurus dev server — all six pages compile and render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)